### PR TITLE
Built-in header search bug fix, expanded built-in header search, improved requirements section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Here's some of the work in brief.
 - `clang` installed on your system. (eg. `yum install clang clang-devel` or
   `apt-get install libclang-dev`)
 
+To get clang_complete working with
+[NCM](https://github.com/roxma/nvim-complete-manager) you must install the
+[`neovim`](https://pypi.python.org/pypi/neovim/) Python package *for Python 2*.
+clang_complete is invoked with the Python 2 interpreter, not the Python 3
+interpreter, because the clang Python bindings only support Python 2.
+
 ## Installation
 
 Assuming you're using [vim-plug](https://github.com/junegunn/vim-plug).

--- a/pythonx/libclang.py
+++ b/pythonx/libclang.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 from clang.cindex import Config, Index, CompilationDatabase, TranslationUnit, File, SourceLocation, Cursor, TranslationUnitLoadError
 from clang.cindex import CodeCompletionResult
+import glob
+import itertools
 import time
 import threading
 import os
@@ -243,8 +245,11 @@ class ClangWrapper():
             library_path + "/clang",         # opensuse
             library_path + "/",              # Google
             "/usr/lib64/clang",              # x86_64 (openSUSE, Fedora)
-            "/usr/lib/clang"
+            "/usr/lib/clang",
+            "/usr/lib/clang/*",              # centos7
     ]
+    knownPaths = itertools.chain.from_iterable(
+      [glob.glob(path) for path in knownPaths])
 
     for path in knownPaths:
       try:

--- a/pythonx/libclang.py
+++ b/pythonx/libclang.py
@@ -251,7 +251,7 @@ class ClangWrapper():
         subDirs = [f for f in os.listdir(path) if os.path.isdir(path + "/" + f)]
         subDirs = sorted(subDirs) or ['.']
         path = path + "/" + subDirs[-1] + "/include"
-        if canFindBuiltinHeaders(self.index, ["-I" + path]):
+        if self.canFindBuiltinHeaders(self.index, ["-I" + path]):
           return path
       except:
         pass


### PR DESCRIPTION
So this pull request is the result of trying to get your excellent [nvim-completion-manager](https://github.com/roxma/nvim-completion-manager) and [clang_complete fork](https://github.com/roxma/clang_complete) working on CentOS 7. The clang package available from [EPEL](https://fedoraproject.org/wiki/EPEL) puts things in some strange locations. The library itself is found at `/usr/lib64/llvm/libclang.so` but the built-in headers are found in `/usr/lib/clang/3.4.2/include/`. I expanded the header search by using a clob on `/usr/lib/clang` (see [here](https://github.com/roxma/clang_complete/compare/master...vietjtnguyen:master#diff-cd4785874f4d0046ab1d86db09ead7afR249)).

While debugging (enabling logging per your [trouble shooting wiki](https://github.com/roxma/nvim-completion-manager/wiki/Trouble-shooting)) I noticed that `canFindBuiltinHeaders()` was *not* being called for these extra search paths. It appears that it was mistakenly being called as a free function rather than a member function. However, I'm not sure why that didn't show up as an error, unless there is a free function named `canFindBuiltinHeaders` (I did not see one).

Finally, the last piece to getting things working was installing the neovim pip package for my Python 2 installation. I had neovim installed for Python 3. After some debugging I noticed that the clang_complete source process was being kicked off but when checking the process (via the PID in the logs) it would always be dead. I then changed the [`Popen()` call](https://github.com/roxma/nvim-completion-manager/blob/22d9dac318113840c28f7e1292d330c246f37de3/pythonx/cm_core.py#L678) to share the `stdout` and `stderr` so that I can see what was going on in the clang_complete source process. That's when I found out that it was dying *very* early on due to an import error trying to import neovim. That's when I connected the dots and realized the clang_complete source process was invoked using Python 2 and that I had not installed the neovim package for Python 2. After installing it everything worked fine. I updated the README to explain this requirement.

I'm also going to throw a pull request your way for nvim-completion-manager to enable (via environment variables) the `stdout` and `stderr` sharing for the source processes, similar to how I debugged the import error.